### PR TITLE
Couple small updates

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -33,17 +33,6 @@
     },
     "modules": [
         {
-            "name": "libgee",
-            "config-opts": [ "--disable-static" ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libgee.git",
-                    "tag": "0.20.2"
-                }
-            ]
-        },
-        {
             "name": "granite",
             "buildsystem": "meson",
             "sources": [

--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -32,6 +32,28 @@
         }
     },
     "modules": [
+         {
+            "name": "icons",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/elementary/icons.git",
+                    "tag": "5.1.0"
+                }
+            ]
+        },
+        {
+            "name": "stylesheet",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/elementary/stylesheet.git",
+                    "tag": "5.3.0"
+                }
+            ]
+        },
         {
             "name": "granite",
             "buildsystem": "meson",

--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -50,7 +50,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/elementary/granite.git",
-                    "tag": "5.2.4"
+                    "tag": "5.2.5"
                 }
             ]
         },
@@ -94,39 +94,6 @@
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz",
                             "sha256": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "libunity",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "bzr",
-                    "url": "https://code.launchpad.net/~unity-team/libunity/trunk"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "libdbusmenu",
-                    "buildsystem": "autotools",
-                    "config-opts": [ "--disable-dumper" ],
-                    "sources": [
-                        {
-                            "type": "bzr",
-                            "url": "https://code.launchpad.net/~dbusmenu-team/libdbusmenu/trunk.16.10"
-                        }
-                    ]
-                },
-                {
-                    "name": "dee",
-                    "buildsystem": "autotools",
-                    "sources": [
-                        {
-                            "type": "bzr",
-                            "url": "https://code.launchpad.net/~unity-team/dee/trunk"
                         }
                     ]
                 }

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('io.elementary.Sdk', version: '0.1.0')
 
 data = configuration_data()
 data.set('SDK_BRANCH', meson.project_version())
-data.set('GNOME_VERSION', '3.32')
+data.set('GNOME_VERSION', '3.34')
 
 sdk_json = configure_file(
     input: 'io.elementary.Sdk.json.in',


### PR DESCRIPTION
* Update granite and drop libunity :tada: 
* drop libgee, see #2
* Update base gnome runtime
* start bundling the elementary stylesheet in the runtime iself, groundwork for #1