### PR TITLE
Inherit freedesktop runtime extensions

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -8,6 +8,14 @@
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.gnome.Sdk.Debug", "org.gnome.Sdk.Locale", "org.gnome.Sdk.Docs"],
     "platform-extensions": [ "org.gnome.Platform.Locale"],
+    "inherit-extensions": [
+        "org.freedesktop.Platform.GL",
+        "org.freedesktop.Platform.VAAPI.Intel",
+        "org.freedesktop.Platform.Timezones",
+        "org.freedesktop.Platform.GStreamer",
+        "org.freedesktop.Platform.openh264",
+        "org.freedesktop.Sdk.Extension"
+    ],
     "finish-args": [
         "--env=GI_TYPELIB_PATH=/app/lib/girepository-1.0",
         "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/share",


### PR DESCRIPTION
so now, apps can use them with the elementary runtime.