### PR TITLE
fix extension inheritance

### DIFF
--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -13,7 +13,9 @@
         "org.freedesktop.Platform.VAAPI.Intel",
         "org.freedesktop.Platform.Timezones",
         "org.freedesktop.Platform.GStreamer",
-        "org.freedesktop.Platform.openh264",
+        "org.freedesktop.Platform.openh264"
+    ],
+    "inherit-sdk-extensions": [
         "org.freedesktop.Sdk.Extension"
     ],
     "finish-args": [


### PR DESCRIPTION
Sdk extensions have their own inherit key, putting them along
with the normal ones, causes thing to break badly.

Close #19