### PR TITLE
io.elementary.Sdk.json: base it on GNOME 41 runtime

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,12 +22,12 @@ jobs:
           - name: daily-aarch64
             packages: io.elementary.Platform/aarch64/daily io.elementary.Sdk/aarch64/daily
             tags: ghcr.io/${{ github.repository }}/runtime:daily-aarch64
-          - name: stable-6-x86_64
-            packages: io.elementary.Platform/x86_64/6 io.elementary.Sdk/x86_64/6
-            tags: ghcr.io/${{ github.repository }}/runtime:6,ghcr.io/${{ github.repository }}/runtime:6-x86_64
-          - name: stable-6-aarch64
-            packages: io.elementary.Platform/aarch64/6 io.elementary.Sdk/aarch64/6
-            tags: ghcr.io/${{ github.repository }}/runtime:6-aarch64
+          - name: stable-6.1-x86_64
+            packages: io.elementary.Platform/x86_64/6.1 io.elementary.Sdk/x86_64/6
+            tags: ghcr.io/${{ github.repository }}/runtime:6.1,ghcr.io/${{ github.repository }}/runtime:6.1-x86_64
+          - name: stable-6.1-aarch64
+            packages: io.elementary.Platform/aarch64/6.1 io.elementary.Sdk/aarch64/6
+            tags: ghcr.io/${{ github.repository }}/runtime:6.1-aarch64
 
     services:
       registry:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           DISPLAY: "0:0"
         run: |
-          sudo xvfb-run --auto-servernum flatpak-builder --default-branch="6" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --default-branch="6.1" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -3,7 +3,7 @@
     "id": "io.elementary.Sdk",
     "id-platform": "io.elementary.Platform",
     "default-branch": "daily",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -3,7 +3,7 @@
     "id": "io.elementary.Sdk",
     "id-platform": "io.elementary.Platform",
     "default-branch": "daily",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
@@ -124,24 +124,6 @@
                     "type": "git",
                     "url": "https://github.com/elementary/granite.git",
                     "tag": "6.1.0"
-                }
-            ]
-        },
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dintrospection=enabled",
-                "-Dvapi=true",
-                "-Dgtk_doc=true",
-                "-Dtests=false",
-                "-Dexamples=false"
-            ],
-            "sources" : [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag": "1.2.0"
                 }
             ]
         },


### PR DESCRIPTION
Advantages of doing this, apart for all the underlying updates and security fixes:
- GNOME 3.38 is now deprecated
- You can use libhandy from the GNOME runtime