### PR TITLE
daily: Add cross-compilation of aarch64 architecture

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           DISPLAY: "0:0"
         run: |
-          sudo xvfb-run --arch=${{ matrix.arch }} --auto-servernum flatpak-builder --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.arch }} --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,6 +3,7 @@
 name: Daily
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -15,6 +16,10 @@ jobs:
     name: Publish Platform
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+
     steps:
       - name: Clean
         uses: easimon/maximize-build-space@v4
@@ -25,6 +30,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
 
       - name: Setup
         run: |
@@ -52,7 +62,7 @@ jobs:
         env:
           DISPLAY: "0:0"
         run: |
-          sudo xvfb-run --auto-servernum flatpak-builder --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
+          sudo xvfb-run --arch=${{ matrix.arch }} --auto-servernum flatpak-builder --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
+      fail-fast: false
 
     steps:
       - name: Clean

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,7 +3,6 @@
 name: Daily
 
 on:
-  workflow_dispatch: {}
   push:
     branches:
       - main


### PR DESCRIPTION
In theory allows us to also push an arm64 version of the Platform/SDK to the daily remote too. I've tested that this builds, but haven't seen what the behavior is when it gets pushed to the flatpak remote yet.

Hence, I've only added this to the daily workflow for now and these changes will need transferring to the stable workflow once we're happy they work well.
