### PR TITLE
daily: Cache per-arch

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./.flatpak-builder
-          key: flatpak-builder-${{ github.sha }}
+          key: flatpak-builder-${{ github.sha }}-${{ matrix.arch }}
           restore-keys: |
             flatpak-builder-
             flatpak-


### PR DESCRIPTION
Follow up to #53 

The cache is only relevant to the architecture being built, so make sure to separate them