### PR TITLE
Release 6.0.1

### DIFF
--- a/data/platform.appdata.xml.in
+++ b/data/platform.appdata.xml.in
@@ -10,6 +10,11 @@
     <p>The Flatpak platform for elementary OS and AppCenter.</p>
   </description>
   <releases>
+    <release version="6.0.1" date="2021-08-23" urgency="medium">
+      <description>
+        <p>Add support for ARM (aarch64)</p>
+      </description>
+    </release>
     <release version="6.0.0" date="2021-07-20" urgency="medium">
       <description>
         <p>Initial Release</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'io.elementary.Platform',
-    version: '6.0.0'
+    version: '6.0.1'
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
Enabled ARM support, so we should make a new release to be able to start building against that.