### PR TITLE
Improve GHCR container building

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,7 @@ jobs:
           - name: x86
             platform: false
             architecture: x86_64
-        
+
           - name: ARM
             platform: arm64
             architecture: aarch64
@@ -100,22 +100,3 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.FLAT_MANAGER_TOKEN }}
         run: flat-manager-client purge ${{ env.build_id }}
-
-  publish_docker:
-    name: Publish Docker
-    runs-on: ubuntu-latest
-    needs: publish_platform
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Publish
-        uses: docker/build-push-action@v1
-        with:
-          push: true
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          repository: ${{ github.repository }}/runtime
-          tags: daily

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,19 +3,15 @@
 name: Docker
 
 on:
-  workflow_dispatch: {}
-
-  push:
-    branches:
-      - main
-
-  schedule:
-    - cron: "0 5 * * *"
+  workflow_run:
+    workflows: ["Daily", "Release"]
+    types: [completed]
 
 jobs:
   publish_docker:
     name: Publish Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,73 @@
+---
+
+name: Docker
+
+on:
+  workflow_dispatch: {}
+
+  push:
+    branches:
+      - main
+
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  publish_docker:
+    name: Publish Docker
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        runtime:
+          - name: daily-x86_64
+            packages: io.elementary.Platform/x86_64/daily io.elementary.Sdk/x86_64/daily
+            tags: ghcr.io/${{ github.repository }}/runtime:daily,ghcr.io/${{ github.repository }}/runtime:daily-x86_64
+          - name: daily-aarch64
+            packages: io.elementary.Platform/aarch64/daily io.elementary.Sdk/aarch64/daily
+            tags: ghcr.io/${{ github.repository }}/runtime:daily-aarch64
+          - name: stable-6-x86_64
+            packages: io.elementary.Platform/x86_64/6 io.elementary.Sdk/x86_64/6
+            tags: ghcr.io/${{ github.repository }}/runtime:6,ghcr.io/${{ github.repository }}/runtime:6-x86_64
+          - name: stable-6-aarch64
+            packages: io.elementary.Platform/aarch64/6 io.elementary.Sdk/aarch64/6
+            tags: ghcr.io/${{ github.repository }}/runtime:6-aarch64
+
+    services:
+      registry:
+        image: registry:latest
+        ports:
+          - 5000:5000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push the base image to local registry
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: .
+          push: true
+          tags: localhost:5000/ubuntu-base:latest
+
+      - name: Write the Dockerfile for the ${{ matrix.runtime.name }} runtime
+        run: |
+          cat >> ${{ matrix.runtime.name }}.Dockerfile << EOF
+          # syntax = docker/dockerfile:experimental
+          FROM localhost:5000/ubuntu-base:latest
+          RUN flatpak install -y --noninteractive appcenter ${{ matrix.runtime.packages }}
+
+      - name: Build & push the ${{ matrix.runtime.name }} image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: .
+          push: true
+          file: ${{ matrix.runtime.name }}.Dockerfile
+          tags: ${{ matrix.runtime.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,22 +99,3 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.FLAT_MANAGER_TOKEN }}
         run: flat-manager-client purge ${{ env.build_id }}
-
-  publish_docker:
-    name: Publish Docker
-    runs-on: ubuntu-latest
-    needs: publish_platform
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Publish
-        uses: docker/build-push-action@v1
-        with:
-          push: true
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-          repository: ${{ github.repository }}/runtime
-          tags: "6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM bilelmoussaoui/flatpak-github-actions:gnome-3.38
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get -y install flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gi xvfb ccache zstd docker.io && \
+    apt-get -y autoremove && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN flatpak remote-add --if-not-exists appcenter https://flatpak.elementary.io/repo.flatpakrepo
 
-RUN flatpak install -y appcenter \
-  io.elementary.Platform//daily \
-  io.elementary.Sdk//daily
+ADD https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client /usr/bin
+RUN chmod +x /usr/bin/flat-manager-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get -y install flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gi xvfb ccache zstd docker.io && \
+    apt-get -y install flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gi libostree-dev xvfb ccache zstd docker.io && \
     apt-get -y autoremove && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #66

Currently, there is only one Dockerfile to build and push a container to ghcr. This includes only the daily platform/SDK from the appcenter flatpak remote. 

The intention of these containers is to speed up builds and reduce the bandwidth from the appcenter remote as every CI build of every app won't have to pull down the platform/SDK from the public remote, and it can instead pull a container that already includes it from GitHub's own infrastructure.

However, given that we only publish a container with the daily runtime, all of the CI jobs for the appcenter dashboard are currently having to download the platform/SDK every time, because they use the `6` branch.

So:

- Build a "base image" that includes `flatpak`, `flatpak-builder`, `flat-manager-client` and `docker` (for QEMU emulation support)
- From this base image, build a collection of tagged images that support every combination of `daily`/`6` and `x86_64`/`aarch64` with the relevant platforms/SDKs installed.
- Move this out to a separate workflow to make it more obvious what's going on

I've tested these workflows and containers over at https://github.com/davidmhewitt/torrential/pull/159/files and confirmed that no runtimes/SDKs are downloaded from the flatpak remote, for both x86 and aarch64 architectures.