### PR TITLE
Claim more space for the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,14 @@ jobs:
       - name: Clean
         uses: easimon/maximize-build-space@v4
         with:
-          root-reserve-mb: 20480
+          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # where we need the most space
+          root-reserve-mb: 16000
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: easimon/maximize-build-space@v4
         with:
           # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
           # where we need the most space
           root-reserve-mb: 16000
           swap-size-mb: 1024

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -31,9 +31,14 @@ jobs:
       - name: Clean
         uses: easimon/maximize-build-space@v4
         with:
-          root-reserve-mb: 25600
+          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # where we need the most space
+          root-reserve-mb: 16000
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -32,7 +32,7 @@ jobs:
         uses: easimon/maximize-build-space@v4
         with:
           # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
           # where we need the most space
           root-reserve-mb: 16000
           swap-size-mb: 1024

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: easimon/maximize-build-space@v4
         with:
           # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
           # where we need the most space
           root-reserve-mb: 16000
           swap-size-mb: 1024

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,14 @@ jobs:
       - name: Clean
         uses: easimon/maximize-build-space@v4
         with:
-          root-reserve-mb: 25600
+          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+          # This probably needs around 10-12GB, the of the free space on / then gets assigned to the build directory
+          # where we need the most space
+          root-reserve-mb: 16000
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
If you look at the Actions results history, you can see there are a bunch of failures. Most of which are caused by the builder running out of disk space.

If my sums are right, we don't need to reserve 25.6GB on the `/` partition since the GNOME runtimes that get installed to there as dependencies of the build only add up to around 10GB, so we can release some of that space, and the `maximize-build-space` action will then assign it to the build directory instead, which is where we keep running out of space.

We can even gain a bit more space to steal from `/` by removing the haskell and android runtimes from the runner too.