### PR TITLE
Revert "Add LibAdwaita"

### DIFF
--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -117,17 +117,6 @@
             ]
         },
         {
-            "name": "adwaita",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "tag": "1.0.0.alpha.4"
-                }
-            ]
-        },
-        {
             "name": "granite",
             "buildsystem": "meson",
             "sources": [


### PR DESCRIPTION
Reverts elementary/flatpak-platform#83

thinking about this more, it probably doesn’t make sense to include something without a stable API here. It would be better for apps to bundle this since we wouldn’t be able to update it here without breaking them anyways. We can include Adwaita when it hits stability