### PR TITLE
Add Default Settings

### DIFF
--- a/data/platform.appdata.xml.in
+++ b/data/platform.appdata.xml.in
@@ -16,6 +16,7 @@
         <ul>
           <li>Rebase on GNOME 41 runtime</li>
           <li>Added elementary and freedesktop sound themes</li>
+          <li>Use the correct stylesheet on OS 5</li>
         </ul>
       </description>
     </release>

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -179,7 +179,7 @@
                 }
             ],
             "build-commands": [
-                "ln -S /usr/share/themes/io.elementary.stylesheet.blueberry /usr/share/themes/elementary"
+                "ln -s /usr/share/themes/io.elementary.stylesheet.blueberry /usr/share/themes/elementary"
             ]
         },
         {

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -161,6 +161,28 @@
             ]
         },
         {
+            "name" : "platform-settings",
+            "buildsystem" : "simple",
+            "modules": [
+                {
+                    "name" : "default-gtk-settings",
+                    "buildsystem" : "simple",
+                    "sources" : [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/elementary/default-settings.git"
+                        }
+                    ],
+                    "build-commands": [
+                        "install -Dm644 gtk/settings.ini /usr/etc/gtk-3.0/settings.ini"
+                    ]
+                }
+            ],
+            "build-commands": [
+                "ln -S /usr/share/themes/io.elementary.stylesheet.blueberry /usr/share/themes/elementary"
+            ]
+        },
+        {
             "name" : "appdata",
             "buildsystem" : "meson",
             "sources" : [


### PR DESCRIPTION
Fixes #28
This is just the default settings stuff from https://github.com/elementary/flatpak-platform/pull/30/files

Makes apps on OS 5 use the correct stylesheet

It woorkssss:
![Screenshot from 2021-12-03 20 46 01](https://user-images.githubusercontent.com/7277719/144697462-7183aa0b-a385-42d5-9d5a-7bf841e0477f.png)
![Screenshot from 2021-12-03 20 47 37](https://user-images.githubusercontent.com/7277719/144697464-72c1cbc9-e61b-46fc-a4c4-055e4779427f.png)
