### PR TITLE
docker: Ensure correct SDK version is installed in 6.1 image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,10 @@ jobs:
             packages: io.elementary.Platform/aarch64/daily io.elementary.Sdk/aarch64/daily
             tags: ghcr.io/${{ github.repository }}/runtime:daily-aarch64
           - name: stable-6.1-x86_64
-            packages: io.elementary.Platform/x86_64/6.1 io.elementary.Sdk/x86_64/6
+            packages: io.elementary.Platform/x86_64/6.1 io.elementary.Sdk/x86_64/6.1
             tags: ghcr.io/${{ github.repository }}/runtime:6.1,ghcr.io/${{ github.repository }}/runtime:6.1-x86_64
           - name: stable-6.1-aarch64
-            packages: io.elementary.Platform/aarch64/6.1 io.elementary.Sdk/aarch64/6
+            packages: io.elementary.Platform/aarch64/6.1 io.elementary.Sdk/aarch64/6.1
             tags: ghcr.io/${{ github.repository }}/runtime:6.1-aarch64
 
     services:


### PR DESCRIPTION
Missed in #52 