### PR TITLE
Switch daily to 7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Docker
 
 on:
   workflow_run:
-    workflows: ["Daily", "Release"]
+    workflows: ["Daily", "Release-7"]
     types: [completed]
 
 jobs:
@@ -22,12 +22,12 @@ jobs:
           - name: daily-aarch64
             packages: io.elementary.Platform/aarch64/daily io.elementary.Sdk/aarch64/daily
             tags: ghcr.io/${{ github.repository }}/runtime:daily-aarch64
-          - name: stable-6.1-x86_64
-            packages: io.elementary.Platform/x86_64/6.1 io.elementary.Sdk/x86_64/6.1
-            tags: ghcr.io/${{ github.repository }}/runtime:6.1,ghcr.io/${{ github.repository }}/runtime:6.1-x86_64
-          - name: stable-6.1-aarch64
-            packages: io.elementary.Platform/aarch64/6.1 io.elementary.Sdk/aarch64/6.1
-            tags: ghcr.io/${{ github.repository }}/runtime:6.1-aarch64
+          # - name: stable-7-x86_64
+          #   packages: io.elementary.Platform/x86_64/7 io.elementary.Sdk/x86_64/7
+          #   tags: ghcr.io/${{ github.repository }}/runtime:7,ghcr.io/${{ github.repository }}/runtime:7-x86_64
+          # - name: stable-7-aarch64
+          #   packages: io.elementary.Platform/aarch64/7 io.elementary.Sdk/aarch64/7
+          #   tags: ghcr.io/${{ github.repository }}/runtime:7-aarch64
 
     services:
       registry:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 
-name: Release
+name: Release-7
 
 on:
   pull_request:
@@ -72,7 +72,7 @@ jobs:
         env:
           DISPLAY: "0:0"
         run: |
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="6.1" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="7" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -128,6 +128,17 @@
             ]
         },
         {
+            "name": "granite-7",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/elementary/granite.git",
+                    "branch": "main"
+                }
+            ]
+        },
+        {
             "name" : "sound-theme",
             "buildsystem" : "meson",
             "sources" : [

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -61,9 +61,9 @@
                     "cleanup": [ "*" ],
                     "sources": [
                         {
-                            "type": "git",
-                            "url": "https://gitlab.freedesktop.org/xorg/app/xcursorgen.git",
-                            "tag": "xcursorgen-1.0.7"
+                            "type": "archive",
+                            "url": "https://xorg.freedesktop.org/archive/individual/app/xcursorgen-1.0.7.tar.gz",
+                            "sha256": "6bc32d4977ffd60c00583bfd217f1d1245ca54dafbfbbcdbf14f696f9487b83e"
                         }
                     ]
                 }

--- a/io.elementary.Sdk.json
+++ b/io.elementary.Sdk.json
@@ -52,7 +52,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/elementary/icons.git",
-                    "tag": "6.1.0"
+                    "branch": "master"
                 }
             ],
             "modules": [
@@ -76,7 +76,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/elementary/stylesheet.git",
-                    "tag": "6.1.1"
+                    "branch": "master"
                 }
             ],
             "modules": [


### PR DESCRIPTION
We want the daily runtime to target the `7` platform. I've disabled the docker builds for the stable runtime for now, as they'll fail until we've pushed the first stable version of `7`.

I've already branched off `6.1` that we can use to push updates to the current release if we need to.