### PR TITLE
Remove installation of settings.ini

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -177,21 +177,6 @@
         {
             "name" : "platform-settings",
             "buildsystem" : "simple",
-            "modules": [
-                {
-                    "name" : "default-gtk-settings",
-                    "buildsystem" : "simple",
-                    "sources" : [
-                        {
-                            "type": "git",
-                            "url": "https://github.com/elementary/default-settings.git"
-                        }
-                    ],
-                    "build-commands": [
-                        "install -Dm644 gtk/settings.ini /usr/etc/gtk-3.0/settings.ini"
-                    ]
-                }
-            ],
             "build-commands": [
                 "ln -s /usr/share/themes/io.elementary.stylesheet.blueberry /usr/share/themes/elementary"
             ]


### PR DESCRIPTION
This file is removed in elementary/default-settings#305 and causes the latest build failing:

```
========================================================================
Building module default-gtk-settings in /home/runner/work/flatpak-platform/flatpak-platform/.flatpak-builder/build/default-gtk-settings-1
========================================================================
Already on 'master'
Running: install -Dm644 gtk/settings.ini /usr/etc/gtk-3.0/settings.ini
install: cannot stat 'gtk/settings.ini': No such file or directory
Error: module default-gtk-settings: Child process exited with code 1
Error: Process completed with exit code 1.
```

https://github.com/elementary/flatpak-platform/actions/runs/8906581018/job/24458972139