### PR TITLE
Add x-checker-data for xcursorgen

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -66,7 +66,12 @@
                         {
                             "type": "archive",
                             "url": "https://xorg.freedesktop.org/archive/individual/app/xcursorgen-1.0.7.tar.gz",
-                            "sha256": "6bc32d4977ffd60c00583bfd217f1d1245ca54dafbfbbcdbf14f696f9487b83e"
+                            "sha256": "6bc32d4977ffd60c00583bfd217f1d1245ca54dafbfbbcdbf14f696f9487b83e",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 21210,
+                                "url-template": "https://xorg.freedesktop.org/archive/individual/app/xcursorgen-$version.tar.gz"
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
Tested locally:

```
OUTDATED: xcursorgen-1.0.7.tar.gz
 Has a new version:
  URL:       https://xorg.freedesktop.org/archive/individual/app/xcursorgen-1.0.8.tar.gz
  MD5:       33514d3bff35e3b5c70ff71598f8440e
  SHA1:      24c64fa04c6fb94fdfe1842d1afed0dfeadb2432
  SHA256:    b8bb2756918343b8bc15a4ce875e9efb6c4e7777adba088280e53dd09753b6ac
  SHA512:    bea0baab9ce8d56155f4960f28831c623ac28c4facfef51a3ba1282a62a7eb5847bcbc565fab0a2efefc9077498668920939b2d1721c8f604d97c043a5447d9a
  Size:      162415
  Version:   1.0.8
  Timestamp: 2022-12-03 20:20:44

INFO    src.main: Check finished with 0 error(s)
```