### PR TITLE
Release 8.0

### DIFF
--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -10,7 +10,7 @@
     <p>The Flatpak platform for elementary OS and AppCenter.</p>
   </description>
   <releases>
-    <release version="8.0.0" date="2024-04-29" urgency="medium">
+    <release version="8.0.0" date="2024-05-02" urgency="medium">
       <description>
         <p>Platform updates:</p>
         <ul>

--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -10,7 +10,7 @@
     <p>The Flatpak platform for elementary OS and AppCenter.</p>
   </description>
   <releases>
-    <release version="8.0.0" date="2024-05-02" urgency="medium">
+    <release version="8.0.0" date="2024-05-07" urgency="medium">
       <description>
         <p>Platform updates:</p>
         <ul>


### PR DESCRIPTION
Probably should have added the release tag in #147 because the 8.0 runtime is building in the `daily` branch now but an `8.0` Flatpak branch won't be created and pushed until we run the release action.

Edit: Not sure if there are stylesheet or icon releases we want to get in first, or if they'd come in a later release.