### PR TITLE
ci: Correct SDK json path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 on:
   pull_request:
     paths:
-      - io.elementary.Sdk.json
+      - io.elementary.Sdk.json.in
 
     types:
       - opened


### PR DESCRIPTION
This should fix the CI not starting in PRs that modifies `io.elementary.Sdk.json.in` like #178