### PR TITLE
Release 8.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ jobs:
           - 'daily'
           - '7.3'
           - '8'
+          - '8.1'
 
     services:
       registry:

--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -10,11 +10,12 @@
     <p>The Flatpak platform for elementary OS and AppCenter.</p>
   </description>
   <releases>
-    <release version="8.1.0" date="2024-12-26" urgency="medium">
+    <release version="8.1.0" date="2025-02-27" urgency="medium">
       <description>
         <p>Platform updates:</p>
         <ul>
           <li>Rebase on GNOME 47 runtime</li>
+          <li>Update LibPortal to 0.9.1</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
Releases a GNOME 47 based version of the SDK so devs can start basing on that and checking compatibility.

If there are any major breaking ABI changes in Granite coming up, we'd want to get that in first. But the current upcoming changes could be added in a minor release.