### PR TITLE
Bump GNOME platform to 48

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -3,7 +3,7 @@
     "id": "io.elementary.Sdk",
     "id-platform": "io.elementary.Platform",
     "default-branch": "@branch@",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [


### PR DESCRIPTION
We should just bump this to GNOME 48 since nothing has been published with Platform 8.1 yet