### PR TITLE
Actions: Replace broken easimon/maximize-build-space

### DIFF
--- a/.github/actions/maximize-build-space/action.yml
+++ b/.github/actions/maximize-build-space/action.yml
@@ -1,0 +1,30 @@
+name: "Maximize Build Space"
+description: "Remove large artifacts to maximize available build space on GitHub Actions runners."
+runs:
+  using: "composite"
+  steps:
+    - name: Clean
+      shell: bash
+      run: |
+        echo "Available storage before:"
+        sudo df -h
+        echo
+
+        echo "Removing Removes .NET runtime and libraries..."
+        sudo rm -rf /usr/share/dotnet
+
+        echo "Removing Android SDKs and Tools..."
+        sudo rm -rf /usr/local/lib/android
+
+        echo "Removing GHC (Haskell) artifacts..."
+        sudo rm -rf /opt/ghc
+
+        echo "Removing CodeQL Action Bundles..."
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+        echo "Removing cached Docker images..."
+        sudo docker image prune --all --force
+
+        echo "Available storage after:"
+        sudo df -h
+        echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,28 @@ jobs:
 
     steps:
       - name: Clean
-        uses: easimon/maximize-build-space@v10
-        with:
-          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-          # where we need the most space
-          root-reserve-mb: 16000
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
+        # where we need the most space
+        run: |
+          echo "Available storage before:"
+          sudo df -h
+          echo
+
+          # Remove Removes .NET runtime and libraries
+          sudo rm -rf /usr/share/dotnet
+          # Removes Android SDKs and Tools
+          sudo rm -rf /usr/local/lib/android
+          # Removes GHC (Haskell) artifacts
+          sudo rm -rf /opt/ghc
+          # Removes CodeQL Action Bundles
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Removes cached Docker images
+          sudo docker image prune --all --force
+
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,19 @@ jobs:
           sudo df -h
           echo
 
-          # Remove Removes .NET runtime and libraries
+          echo "Removing Removes .NET runtime and libraries..."
           sudo rm -rf /usr/share/dotnet
-          # Removes Android SDKs and Tools
+
+          echo "Removing Android SDKs and Tools..."
           sudo rm -rf /usr/local/lib/android
-          # Removes GHC (Haskell) artifacts
+
+          echo "Removing GHC (Haskell) artifacts..."
           sudo rm -rf /opt/ghc
-          # Removes CodeQL Action Bundles
+
+          echo "Removing CodeQL Action Bundles..."
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          # Removes cached Docker images
+
+          echo "Removing cached Docker images..."
           sudo docker image prune --all --force
 
           echo "Available storage after:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir --state-dir=/mnt/.flatpak-builder ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,36 +31,11 @@ jobs:
             architecture: aarch64
 
     steps:
-      - name: Clean
-        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-        # where we need the most space
-        run: |
-          echo "Available storage before:"
-          sudo df -h
-          echo
-
-          echo "Removing Removes .NET runtime and libraries..."
-          sudo rm -rf /usr/share/dotnet
-
-          echo "Removing Android SDKs and Tools..."
-          sudo rm -rf /usr/local/lib/android
-
-          echo "Removing GHC (Haskell) artifacts..."
-          sudo rm -rf /opt/ghc
-
-          echo "Removing CodeQL Action Bundles..."
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          echo "Removing cached Docker images..."
-          sudo docker image prune --all --force
-
-          echo "Available storage after:"
-          sudo df -h
-          echo
-
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Clean
+        uses: ./.github/actions/maximize-build-space
 
       - name: Setup
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -37,15 +37,19 @@ jobs:
           sudo df -h
           echo
 
-          # Remove Removes .NET runtime and libraries
+          echo "Removing Removes .NET runtime and libraries..."
           sudo rm -rf /usr/share/dotnet
-          # Removes Android SDKs and Tools
+
+          echo "Removing Android SDKs and Tools..."
           sudo rm -rf /usr/local/lib/android
-          # Removes GHC (Haskell) artifacts
+
+          echo "Removing GHC (Haskell) artifacts..."
           sudo rm -rf /opt/ghc
-          # Removes CodeQL Action Bundles
+
+          echo "Removing CodeQL Action Bundles..."
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          # Removes cached Docker images
+
+          echo "Removing cached Docker images..."
           sudo docker image prune --all --force
 
           echo "Available storage after:"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,36 +28,11 @@ jobs:
             architecture: aarch64
 
     steps:
-      - name: Clean
-        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-        # where we need the most space
-        run: |
-          echo "Available storage before:"
-          sudo df -h
-          echo
-
-          echo "Removing Removes .NET runtime and libraries..."
-          sudo rm -rf /usr/share/dotnet
-
-          echo "Removing Android SDKs and Tools..."
-          sudo rm -rf /usr/local/lib/android
-
-          echo "Removing GHC (Haskell) artifacts..."
-          sudo rm -rf /opt/ghc
-
-          echo "Removing CodeQL Action Bundles..."
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          echo "Removing cached Docker images..."
-          sudo docker image prune --all --force
-
-          echo "Available storage after:"
-          sudo df -h
-          echo
-
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Clean
+        uses: ./.github/actions/maximize-build-space
 
       - name: Setup
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -77,7 +77,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build -Dbranch=daily --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir --state-dir=/mnt/.flatpak-builder ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -77,7 +77,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build -Dbranch=daily --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch=daily --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,18 +29,28 @@ jobs:
 
     steps:
       - name: Clean
-        uses: easimon/maximize-build-space@v10
-        with:
-          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-          # where we need the most space
-          root-reserve-mb: 16000
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
+        # where we need the most space
+        run: |
+          echo "Available storage before:"
+          sudo df -h
+          echo
+
+          # Remove Removes .NET runtime and libraries
+          sudo rm -rf /usr/share/dotnet
+          # Removes Android SDKs and Tools
+          sudo rm -rf /usr/local/lib/android
+          # Removes GHC (Haskell) artifacts
+          sudo rm -rf /opt/ghc
+          # Removes CodeQL Action Bundles
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Removes cached Docker images
+          sudo docker image prune --all --force
+
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,28 @@ jobs:
 
     steps:
       - name: Clean
-        uses: easimon/maximize-build-space@v10
-        with:
-          # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-          # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-          # where we need the most space
-          root-reserve-mb: 16000
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
+        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
+        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
+        # where we need the most space
+        run: |
+          echo "Available storage before:"
+          sudo df -h
+          echo
+
+          # Remove Removes .NET runtime and libraries
+          sudo rm -rf /usr/share/dotnet
+          # Removes Android SDKs and Tools
+          sudo rm -rf /usr/local/lib/android
+          # Removes GHC (Haskell) artifacts
+          sudo rm -rf /opt/ghc
+          # Removes CodeQL Action Bundles
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Removes cached Docker images
+          sudo docker image prune --all --force
+
+          echo "Available storage after:"
+          sudo df -h
+          echo
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,19 @@ jobs:
           sudo df -h
           echo
 
-          # Remove Removes .NET runtime and libraries
+          echo "Removing Removes .NET runtime and libraries..."
           sudo rm -rf /usr/share/dotnet
-          # Removes Android SDKs and Tools
+
+          echo "Removing Android SDKs and Tools..."
           sudo rm -rf /usr/local/lib/android
-          # Removes GHC (Haskell) artifacts
+
+          echo "Removing GHC (Haskell) artifacts..."
           sudo rm -rf /opt/ghc
-          # Removes CodeQL Action Bundles
+
+          echo "Removing CodeQL Action Bundles..."
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-          # Removes cached Docker images
+
+          echo "Removing cached Docker images..."
           sudo docker image prune --all --force
 
           echo "Available storage after:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build -Dbranch=${RUNTIME_VERSION} --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="${RUNTIME_VERSION}" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="${RUNTIME_VERSION}" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir --state-dir=/mnt/.flatpak-builder ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           DISPLAY: "0:0"
         run: |
           meson setup build -Dbranch=${RUNTIME_VERSION} --cross-file="architectures/${{ matrix.configuration.architecture }}.crossfile"
-          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="${RUNTIME_VERSION}" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary builddir ./build/io.elementary.Sdk.json
+          sudo xvfb-run --auto-servernum flatpak-builder --arch=${{ matrix.configuration.architecture }} --default-branch="${RUNTIME_VERSION}" --disable-rofiles-fuse --keep-build-dirs --install-deps-from=flathub --ccache --repo=elementary /mnt/builddir ./build/io.elementary.Sdk.json
 
       - name: Fix Permissions
         run: sudo chown -R runner:docker .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,36 +31,11 @@ jobs:
     if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
 
     steps:
-      - name: Clean
-        # Reserve some space on the / partition to install the needed org.gnome runtimes and their Debug extensions.
-        # This probably needs around 10-12GB, the rest of the free space on / then gets assigned to the build directory
-        # where we need the most space
-        run: |
-          echo "Available storage before:"
-          sudo df -h
-          echo
-
-          echo "Removing Removes .NET runtime and libraries..."
-          sudo rm -rf /usr/share/dotnet
-
-          echo "Removing Android SDKs and Tools..."
-          sudo rm -rf /usr/local/lib/android
-
-          echo "Removing GHC (Haskell) artifacts..."
-          sudo rm -rf /opt/ghc
-
-          echo "Removing CodeQL Action Bundles..."
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          echo "Removing cached Docker images..."
-          sudo docker image prune --all --force
-
-          echo "Available storage after:"
-          sudo df -h
-          echo
-
       - name: Checkout
         uses: actions/checkout@v4
+        
+      - name: Clean
+        uses: ./.github/actions/maximize-build-space
 
       - name: Setup
         run: |


### PR DESCRIPTION
Should fix #198

## Changes Summary
- Replace easimon/maximize-build-space by just doing manually what the action does
    - https://github.com/easimon/maximize-build-space/blob/c28619d8999a147d5e09c1199f84ff6af6ad5794/action.yml
- Preserve size of the rootfs by separating state and build directory into different FS
