### PR TITLE
Metainfo: add release notes for 8.2.1

### DIFF
--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -11,6 +11,16 @@
   </description>
 
   <releases>
+    <release version="8.2.1" date="2025-06-03" urgency="medium">
+      <description>
+        <p>Platform updates:</p>
+        <ul>
+          <li>Fix ARM (aarch64) builds not available</li>
+          <li>Update xcursorgen to 1.0.9</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="8.2.0" date="2025-05-14" urgency="medium">
       <description>
         <p>Platform updates:</p>


### PR DESCRIPTION
I'd like to release 8.2.1 to publish aarch64 builds of 8.x platform. It has never been failing to build for a while and just fixed in #199, so declaring 8.x platform to use in your manifest should results build error on aarch64 at the moment. Releasing 8.2.1 should fix this problem.
