### PR TITLE
metainfo: Update release notes for 8.3.0

### DIFF
--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -16,6 +16,8 @@
         <p>Platform updates:</p>
         <ul>
           <li>Rebase on GNOME 49 runtime</li>
+          <li>Update Granite to 7.7.0</li>
+          <li>Update Icons to 8.2.0</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
I'd like to release 8.3.0 of flatpak-platform so that we and community folks can use newer Granite. This is not a release PR but just updates release note so that translators can work on these strings before actual release.
