### PR TITLE
Fix blank flat-manager-client file

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt install -y ccache flatpak flatpak-builder gir1.2-ostree-1.0 meson python3-aiohttp python3-gi python3-tenacity xvfb zstd
           sudo rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-          curl https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} > ./flat-manager-client
+          curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} -o ./flat-manager-client
           sudo mv ./flat-manager-client /usr/bin/flat-manager-client
           sudo chown root: /usr/bin/flat-manager-client
           sudo chmod +x /usr/bin/flat-manager-client

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,11 +23,13 @@ jobs:
             runs-on: ubuntu-22.04
             architecture: x86_64
             flat-manager-suffix: amd64
+            flat-manager-sha256: 9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9
 
           - name: ARM
             runs-on: ubuntu-22.04-arm
             architecture: aarch64
             flat-manager-suffix: arm64
+            flat-manager-sha256: fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956
 
     steps:
       - name: Checkout
@@ -43,6 +45,11 @@ jobs:
           sudo rm -rf /var/lib/{apt,dpkg,cache,log}/
 
           curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} -o ./flat-manager-client
+          SHA256_CALC=$(sha256sum ./flat-manager-client | awk '{ print $1 }')
+          if [ "$SHA256_CALC" != "${{ matrix.configuration.flat-manager-sha256 }}" ]; then
+            echo "flat-manager-client verify error! got $SHA256_CALC"
+            exit 1
+          fi
           sudo mv ./flat-manager-client /usr/bin/flat-manager-client
           sudo chown root: /usr/bin/flat-manager-client
           sudo chmod +x /usr/bin/flat-manager-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,13 @@ jobs:
             runs-on: ubuntu-22.04
             architecture: x86_64
             flat-manager-suffix: amd64
+            flat-manager-sha256: 9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9
 
           - name: ARM
             runs-on: ubuntu-22.04-arm
             architecture: aarch64
             flat-manager-suffix: arm64
+            flat-manager-sha256: fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956
 
     if: github.event.pull_request.merged == true && true == contains(join(github.event.pull_request.labels.*.name), 'Release')
 
@@ -46,6 +48,11 @@ jobs:
           sudo rm -rf /var/lib/{apt,dpkg,cache,log}/
 
           curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} -o ./flat-manager-client
+          SHA256_CALC=$(sha256sum ./flat-manager-client | awk '{ print $1 }')
+          if [ "$SHA256_CALC" != "${{ matrix.configuration.flat-manager-sha256 }}" ]; then
+            echo "flat-manager-client verify error! got $SHA256_CALC"
+            exit 1
+          fi
           sudo mv ./flat-manager-client /usr/bin/flat-manager-client
           sudo chown root: /usr/bin/flat-manager-client
           sudo chmod +x /usr/bin/flat-manager-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt install -y ccache flatpak flatpak-builder gir1.2-ostree-1.0 meson python3-aiohttp python3-gi python3-tenacity xvfb zstd
           sudo rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-          curl https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} > ./flat-manager-client
+          curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} -o ./flat-manager-client
           sudo mv ./flat-manager-client /usr/bin/flat-manager-client
           sudo chown root: /usr/bin/flat-manager-client
           sudo chmod +x /usr/bin/flat-manager-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,23 @@ ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get -y install flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gi libostree-dev xvfb ccache zstd docker.io && \
+    apt-get -y install curl flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gi libostree-dev xvfb ccache zstd docker.io && \
     apt-get -y autoremove && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN flatpak remote-add --if-not-exists appcenter https://flatpak.elementary.io/repo.flatpakrepo
 
-ADD https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.$TARGETARCH /usr/bin/flat-manager-client
+RUN curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.$TARGETARCH -o ./flat-manager-client
+
+RUN SHA256_EXPECTED=$( \
+        case $TARGETARCH in \
+            amd64) echo "9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9";; \
+            arm64) echo "fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956";; \
+        esac \
+    ) && \
+    SHA256_CALC=$(sha256sum ./flat-manager-client | awk '{ print $1 }') && \
+    [ "$SHA256_CALC" = "$SHA256_EXPECTED" ]
+
+RUN mv ./flat-manager-client /usr/bin/flat-manager-client
 RUN chmod +x /usr/bin/flat-manager-client


### PR DESCRIPTION
Followup #230

The current code added in #230 produces a blank flat-manager-client file. This PR fixes the problem by adding `-L` and plus add verification process to prevent such bug and MITM
