### PR TITLE
actions: Update to Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         configuration:
           - name: x86
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             architecture: x86_64
 
           - name: ARM
-            runs-on: ubuntu-22.04-arm
+            runs-on: ubuntu-24.04-arm
             architecture: aarch64
 
     steps:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         configuration:
           - name: x86
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             architecture: x86_64
             flat-manager-suffix: amd64
             flat-manager-sha256: 9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9
 
           - name: ARM
-            runs-on: ubuntu-22.04-arm
+            runs-on: ubuntu-24.04-arm
             architecture: aarch64
             flat-manager-suffix: arm64
             flat-manager-sha256: fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         configuration:
           - name: x86
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             architecture: x86_64
             flat-manager-suffix: amd64
             flat-manager-sha256: 9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9
 
           - name: ARM
-            runs-on: ubuntu-22.04-arm
+            runs-on: ubuntu-24.04-arm
             architecture: aarch64
             flat-manager-suffix: arm64
             flat-manager-sha256: fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956


### PR DESCRIPTION
Because flat-manager-client now requires libc >= 2.38 that is not available on jammy:

    Run BUILD_ID=`flat-manager-client create https://flatpak-api.elementary.io appcenter`
    flat-manager-client: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by flat-manager-client)
    Error: Process completed with exit code 1.

https://github.com/elementary/flatpak-platform/actions/runs/24108492702/job/70337465965
