### PR TITLE
Change cron schedule in daily.yml

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
       - main
 
   schedule:
-    - cron: "10 2 * * *"
+    - cron: "10 2 1/7 * *"
 
 jobs:
   publish_platform:


### PR DESCRIPTION
Updated cron schedule to run every 7 days instead of daily.

One of the reasons that the space requirement of the Flatpak server grew so quickly is many many many revisions of the large Flatpak runtimes/SDKs that honestly don't change that often.

Let's push these weekly (and on change in the repo) instead of daily.