### PR TITLE
Bump GNOME runtime to 50

### DIFF
--- a/io.elementary.Sdk.json.in
+++ b/io.elementary.Sdk.json.in
@@ -3,7 +3,7 @@
     "id": "io.elementary.Sdk",
     "id-platform": "io.elementary.Platform",
     "default-branch": "@branch@",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [

--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2021-2025 elementary, Inc. <contact@elementary.io> -->
+<!-- Copyright 2021-2026 elementary, Inc. <contact@elementary.io> -->
 <component>
   <id>io.elementary.Platform</id>
   <metadata_license>CC0-1.0</metadata_license>
@@ -15,7 +15,7 @@
       <description>
         <p>Platform updates:</p>
         <ul>
-          <li>Rebase on GNOME 49 runtime</li>
+          <li>Rebase on GNOME 50 runtime</li>
           <li>Update Granite to 7.7.0</li>
           <li>Update Icons to 8.2.0</li>
         </ul>


### PR DESCRIPTION
We're planning to rebase on freedesktop platform instead of GNOME platform to fix the big cursor issue in flatpak-platform 8.3 in #220, but inclined to keep on GNOME platform in 8.3. and revisit rebasing in 9, so that things won't break too much for developers when bumping from 8.2.

NOTE: I updated only the essential portion of the appdata file because probably we should add more changes committed since last edited, which would be out of scope of this PR.
