### PR TITLE
metainfo: Update release notes for 8.3.0

### DIFF
--- a/platform-data/data/platform.appdata.xml.in
+++ b/platform-data/data/platform.appdata.xml.in
@@ -16,8 +16,9 @@
         <p>Platform updates:</p>
         <ul>
           <li>Rebase on GNOME 50 runtime</li>
-          <li>Update Granite to 7.7.0</li>
+          <li>Update Granite to 7.8.1</li>
           <li>Update Icons to 8.2.0</li>
+          <li>Update Stylesheet to 8.2.2</li>
         </ul>
       </description>
     </release>

--- a/platform-data/po/extra.pot
+++ b/platform-data/po/extra.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-11 22:23+0900\n"
+"POT-Creation-Date: 2026-05-12 07:54+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,195 +29,199 @@ msgstr ""
 msgid "The Flatpak platform for elementary OS and AppCenter."
 msgstr ""
 
-#: data/platform.appdata.xml.in:16 data/platform.appdata.xml.in:27
-#: data/platform.appdata.xml.in:37 data/platform.appdata.xml.in:47
-#: data/platform.appdata.xml.in:56 data/platform.appdata.xml.in:67
-#: data/platform.appdata.xml.in:79 data/platform.appdata.xml.in:89
-#: data/platform.appdata.xml.in:99 data/platform.appdata.xml.in:110
-#: data/platform.appdata.xml.in:120 data/platform.appdata.xml.in:129
-#: data/platform.appdata.xml.in:143
+#: data/platform.appdata.xml.in:16 data/platform.appdata.xml.in:28
+#: data/platform.appdata.xml.in:38 data/platform.appdata.xml.in:48
+#: data/platform.appdata.xml.in:57 data/platform.appdata.xml.in:68
+#: data/platform.appdata.xml.in:80 data/platform.appdata.xml.in:90
+#: data/platform.appdata.xml.in:100 data/platform.appdata.xml.in:111
+#: data/platform.appdata.xml.in:121 data/platform.appdata.xml.in:130
+#: data/platform.appdata.xml.in:144
 msgid "Platform updates:"
 msgstr ""
 
 #: data/platform.appdata.xml.in:18
-msgid "Rebase on GNOME 49 runtime"
+msgid "Rebase on GNOME 50 runtime"
 msgstr ""
 
 #: data/platform.appdata.xml.in:19
-msgid "Update Granite to 7.7.0"
+msgid "Update Granite to 7.8.1"
 msgstr ""
 
 #: data/platform.appdata.xml.in:20
 msgid "Update Icons to 8.2.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:29
-msgid "Fix ARM (aarch64) builds not available"
+#: data/platform.appdata.xml.in:21
+msgid "Update Stylesheet to 8.2.2"
 msgstr ""
 
 #: data/platform.appdata.xml.in:30
+msgid "Fix ARM (aarch64) builds not available"
+msgstr ""
+
+#: data/platform.appdata.xml.in:31
 msgid "Update xcursorgen to 1.0.9"
 msgstr ""
 
-#: data/platform.appdata.xml.in:39
+#: data/platform.appdata.xml.in:40
 msgid "Rebase on GNOME 48 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:40
+#: data/platform.appdata.xml.in:41
 msgid "Update Stylesheet to 8.2.1"
 msgstr ""
 
-#: data/platform.appdata.xml.in:49
+#: data/platform.appdata.xml.in:50
 msgid "Rebase on GNOME 47 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:50
+#: data/platform.appdata.xml.in:51
 msgid "Update LibPortal to 0.9.1"
 msgstr ""
 
-#: data/platform.appdata.xml.in:58
+#: data/platform.appdata.xml.in:59
 msgid "Update Granite to 7.6.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:59
+#: data/platform.appdata.xml.in:60
 msgid "Update Icons to 8.1.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:60
+#: data/platform.appdata.xml.in:61
 msgid "Update Stylesheet to 8.2.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:61
+#: data/platform.appdata.xml.in:62
 msgid "Update LibPortal to 0.8.1"
 msgstr ""
 
-#: data/platform.appdata.xml.in:69
+#: data/platform.appdata.xml.in:70
 msgid "Rebase on GNOME 46 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:70
+#: data/platform.appdata.xml.in:71
 msgid "Add LibPortal"
 msgstr ""
 
-#: data/platform.appdata.xml.in:71
+#: data/platform.appdata.xml.in:72
 msgid "Update Granite to 7.5.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:72
+#: data/platform.appdata.xml.in:73
 msgid "Update Icons to 8.0.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:73
+#: data/platform.appdata.xml.in:74
 msgid "Update Stylesheet to 8.0.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:81
+#: data/platform.appdata.xml.in:82
 msgid "Rebase on GNOME 45 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:82
+#: data/platform.appdata.xml.in:83
 msgid "Update Granite to 7.4.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:83
+#: data/platform.appdata.xml.in:84
 msgid "Update Stylesheet to 7.3.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:91
+#: data/platform.appdata.xml.in:92
 msgid "Update Granite to 7.3.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:92
+#: data/platform.appdata.xml.in:93
 msgid "Update Icons to 7.3.1"
 msgstr ""
 
-#: data/platform.appdata.xml.in:93
+#: data/platform.appdata.xml.in:94
 msgid "Update Stylesheet to 7.2.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:101
+#: data/platform.appdata.xml.in:102
 msgid "Rebase on GNOME 44 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:102
+#: data/platform.appdata.xml.in:103
 msgid "Update Granite to 7.2.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:103
+#: data/platform.appdata.xml.in:104
 msgid "Update Icons to 7.2.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:104
+#: data/platform.appdata.xml.in:105
 msgid "Update Stylesheet to 7.1.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:112
+#: data/platform.appdata.xml.in:113
 msgid "Update Granite to 7.1.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:113
+#: data/platform.appdata.xml.in:114
 msgid "Update Icons to 7.1.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:114
+#: data/platform.appdata.xml.in:115
 msgid "Update Stylesheet to 7.0.1"
 msgstr ""
 
-#: data/platform.appdata.xml.in:122
+#: data/platform.appdata.xml.in:123
 msgid "Rebase on GNOME 42 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:123
+#: data/platform.appdata.xml.in:124
 msgid "Initial support for Gtk4"
 msgstr ""
 
-#: data/platform.appdata.xml.in:131
+#: data/platform.appdata.xml.in:132
 msgid "Rebase on GNOME 41 runtime"
 msgstr ""
 
-#: data/platform.appdata.xml.in:132
+#: data/platform.appdata.xml.in:133
 msgid "Added elementary and freedesktop sound themes"
 msgstr ""
 
-#: data/platform.appdata.xml.in:133
+#: data/platform.appdata.xml.in:134
 msgid "Use the correct stylesheet on OS 5"
 msgstr ""
 
-#: data/platform.appdata.xml.in:139
+#: data/platform.appdata.xml.in:140
 msgid "Fixes:"
 msgstr ""
 
-#: data/platform.appdata.xml.in:141
+#: data/platform.appdata.xml.in:142
 msgid "Fix localization issues with apps that use Granite"
 msgstr ""
 
-#: data/platform.appdata.xml.in:145
+#: data/platform.appdata.xml.in:146
 msgid "Use the settings portal for time and date settings"
 msgstr ""
 
-#: data/platform.appdata.xml.in:146
+#: data/platform.appdata.xml.in:147
 msgid ""
 "Use the settings portal for color scheme preference instead of requiring an "
 "AccountsService hole"
 msgstr ""
 
-#: data/platform.appdata.xml.in:147
+#: data/platform.appdata.xml.in:148
 msgid "Update elementary stylesheet to 6.1.0"
 msgstr ""
 
-#: data/platform.appdata.xml.in:148
+#: data/platform.appdata.xml.in:149
 msgid "Update Granite to 6.1.2"
 msgstr ""
 
-#: data/platform.appdata.xml.in:154
+#: data/platform.appdata.xml.in:155
 msgid "Add support for ARM (aarch64)"
 msgstr ""
 
-#: data/platform.appdata.xml.in:159 data/sdk.appdata.xml.in:15
+#: data/platform.appdata.xml.in:160 data/sdk.appdata.xml.in:15
 msgid "Initial Release"
 msgstr ""
 
-#: data/platform.appdata.xml.in:164 data/sdk.appdata.xml.in:20
+#: data/platform.appdata.xml.in:165 data/sdk.appdata.xml.in:20
 msgid "elementary, Inc."
 msgstr ""
 


### PR DESCRIPTION
## Changes Summary
- metainfo: Update release notes for 8.3.0 (since last edited in #210)
- Update translation template so that new strings added in the above change gets available for translation

Should be rebase merged.

NOTE: I'll update the release date of 8.3.0 in the appdata file in the release PR (#215)
