### PR TITLE
chore: update flatpak-api endpoint

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.FLAT_MANAGER_TOKEN }}
         run: |
-          BUILD_ID=`flat-manager-client create https://flatpak-api.elementary.io appcenter`
+          BUILD_ID=`flat-manager-client create https://flatpak-api.elementaryos.org appcenter`
           echo "build_id=$BUILD_ID" >> $GITHUB_ENV
 
       - name: Push Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.FLAT_MANAGER_TOKEN }}
         run: |
-          BUILD_ID=`flat-manager-client create https://flatpak-api.elementary.io appcenter`
+          BUILD_ID=`flat-manager-client create https://flatpak-api.elementaryos.org appcenter`
           echo "build_id=$BUILD_ID" >> $GITHUB_ENV
 
       - name: Push Build


### PR DESCRIPTION
Fixes #238 

Seems like the Cloudflare redirect I set up to redirect the old domain to the new doesn't support large file uploads. Point directly to the new endpoint, avoiding the redirect.